### PR TITLE
fix: fix s3_op

### DIFF
--- a/uniflow/op/extract/load/aws/s3_op.py
+++ b/uniflow/op/extract/load/aws/s3_op.py
@@ -2,7 +2,7 @@
 
 import copy
 import logging
-import os
+import tempfile
 from typing import Sequence
 
 from uniflow.node import Node
@@ -38,21 +38,26 @@ class ExtractS3Op(Op):
         for node in nodes:
             value_dict = copy.deepcopy(node.value_dict)
             # create local file path if not exists
-            if os.path.exists(self.LOCAL_FILE_PATH) is False:
-                os.makedirs(self.LOCAL_FILE_PATH)
-            filename = os.path.join(self.LOCAL_FILE_PATH, value_dict["key"])
-            logger.info("Downloading %s to %s", value_dict["key"], filename)
-            self._s3_client.download_file(
-                Bucket=value_dict["bucket"],
-                Key=value_dict["key"],
-                Filename=filename,
+            logger.info(
+                "Downloading file from s3://%s/%s to %s",
+                value_dict["bucket"],
+                value_dict["key"],
+                self.LOCAL_FILE_PATH,
             )
-            with open(
-                filename,
-                "r",
-                encoding=value_dict.get("encoding", "utf-8"),
-            ) as f:
-                text = f.read()
+            with tempfile.NamedTemporaryFile(
+                dir=self.LOCAL_FILE_PATH, delete=False
+            ) as temp_file:
+                self._s3_client.download_file(
+                    Bucket=value_dict["bucket"],
+                    Key=value_dict["key"],
+                    Filename=temp_file.name,
+                )
+                with open(
+                    temp_file.name,
+                    "r",
+                    encoding=value_dict.get("encoding", "utf-8"),
+                ) as f:
+                    text = f.read()
             output_nodes.append(
                 Node(
                     name=self.unique_name(),


### PR DESCRIPTION
Previous implementation will cause a bug when the S3 object key contains multiple levels of folders. The previous code is unable to download them and will generate an empty string. For example, if `value_dict["key"]` is "test_client/test.txt", the download will fail and the text will be empty.

Previous Implementation:
```
filename = os.path.join(self.LOCAL_FILE_PATH, value_dict["key"])
logger.info("Downloading %s to %s", value_dict["key"], filename)
self._s3_client.download_file(
    Bucket=value_dict["bucket"],
    Key=value_dict["key"],
    Filename=filename)
```

In this pull request, I have implemented a solution using `tempfile`, which can resolve this issue.